### PR TITLE
chore: add more data to seed.sql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ supabase/.temp
 next-env.d.ts
 
 # Kiro settings
-.kiro
+.claude
 
 # Docs
 docs/doc_build

--- a/.mise/prepare-state.toml
+++ b/.mise/prepare-state.toml
@@ -1,3 +1,3 @@
 [providers.bun]
-"bun.lock" = "74a4edfa0384261e9bffba581980a9772f40f48bbc31047627bc73b17d9faf5b"
-"package.json" = "b8d12171d2577195be169cf1c934b986a1b0720b1067bac307e6475cf510364b"
+"bun.lock" = "d59e368dbb7093c17df3f9ff4a1ee45dad54edb37fc555eed25ca5472886dfcb"
+"package.json" = "35dca47578b0888097c96d9c0a6aef0e1de44cf6b5282ca698b0c02ce7c57700"

--- a/bun.lock
+++ b/bun.lock
@@ -13,11 +13,11 @@
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/material-nextjs": "^9.0.0",
-        "@supabase/ssr": "^0.10.0",
-        "@supabase/supabase-js": "^2.102.1",
-        "next": "^16.2.2",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
+        "@supabase/ssr": "^0.10.2",
+        "@supabase/supabase-js": "^2.103.0",
+        "next": "^16.2.3",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.10",
@@ -188,43 +188,43 @@
 
     "@mui/utils": ["@mui/utils@9.0.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@mui/types": "^9.0.0", "@types/prop-types": "^15.7.15", "clsx": "^2.1.1", "prop-types": "^15.8.1", "react-is": "^19.2.4" }, "peerDependencies": { "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg=="],
 
-    "@next/env": ["@next/env@16.2.2", "", {}, "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ=="],
+    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.102.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-2uH2WB0H98TOGDtaFWhxIcR42Dro/VB7VDZanz/4bVJsqioIue1m3TUqu3xciDm2W9r+1LXQvYNsYbQfWmD+uQ=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.102.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-UcrcKTPnAIo+Yp9Jjq9XXwFbsmgRYY637mwka9ZjmTIWcX/xr1pote4OVvaGQycVY1KTiQgjMvpC0Q0yJhRq3w=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.0", "", {}, "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.102.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-InLvXKAYf8BIqiv9jWOYudWB3rU8A9uMbcip5BQ5sLLNPrbO1Ekkr79OvlhZBgMNSppxVyC7wPPGzLxMcTZhlA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.102.1", "", { "dependencies": { "@supabase/phoenix": "^0.4.0", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-h2fCumib/v6u7XMwSPgxnpfimjX4xCEayUHrxWLC7UurfQjUZJ0pmJDgm6yj80DnUerxuulRghwm5zXYysFG/Q=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.103.0", "", { "dependencies": { "@supabase/phoenix": "^0.4.0", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ=="],
 
-    "@supabase/ssr": ["@supabase/ssr@0.10.0", "", { "dependencies": { "cookie": "^1.0.2" }, "peerDependencies": { "@supabase/supabase-js": "^2.100.1" } }, "sha512-36jIu+DuKzg5EgA3fnH+zHvwASvpKcL4zPgmHoZaULroS5Q4mzeHcM69zJ0sXUHddO5IcHjQNZJ9Vyhl/DdbRw=="],
+    "@supabase/ssr": ["@supabase/ssr@0.10.2", "", { "dependencies": { "cookie": "^1.0.2" }, "peerDependencies": { "@supabase/supabase-js": "^2.102.1" } }, "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.102.1", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-eCL9T4Xpe40nmKlkUJ7Zq/hk34db1xPiT0WL3Iv5MbJqHuCAe5TxhV8Rjqd6DNZrzjtfYObZtYl9jKJaHrivqw=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.103.0", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.102.1", "", { "dependencies": { "@supabase/auth-js": "2.102.1", "@supabase/functions-js": "2.102.1", "@supabase/postgrest-js": "2.102.1", "@supabase/realtime-js": "2.102.1", "@supabase/storage-js": "2.102.1" } }, "sha512-bChxPVeLDnYN9M2d/u4fXsvylwSQG5grAl+HN8f+ZD9a9PuVU+Ru+xGmEsk+b9Iz3rJC9ZQnQUJYQ28fApdWYA=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.103.0", "", { "dependencies": { "@supabase/auth-js": "2.103.0", "@supabase/functions-js": "2.103.0", "@supabase/postgrest-js": "2.103.0", "@supabase/realtime-js": "2.103.0", "@supabase/storage-js": "2.103.0" } }, "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -318,7 +318,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@16.2.2", "", { "dependencies": { "@next/env": "16.2.2", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.2", "@next/swc-darwin-x64": "16.2.2", "@next/swc-linux-arm64-gnu": "16.2.2", "@next/swc-linux-arm64-musl": "16.2.2", "@next/swc-linux-x64-gnu": "16.2.2", "@next/swc-linux-x64-musl": "16.2.2", "@next/swc-win32-arm64-msvc": "16.2.2", "@next/swc-win32-x64-msvc": "16.2.2", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A=="],
+    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -342,9 +342,9 @@
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/material-nextjs": "^9.0.0",
-    "@supabase/ssr": "^0.10.0",
-    "@supabase/supabase-js": "^2.102.1",
-    "next": "^16.2.2",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.103.0",
+    "next": "^16.2.3",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -44,8 +44,66 @@ insert into auth.identities (
 
 -- Seed orders
 insert into public.orders (id, set1, hidden) values
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '[]'::jsonb, '[]'::jsonb),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '[]'::jsonb, '[]'::jsonb);
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+   '[
+     {"fileName":"titleimg_pc.png","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/titleimg_pc.png","type":"image","viewTime":10000},
+     {"fileName":"service_rn.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/service_rn.jpg","type":"image","viewTime":10000},
+     {"fileName":"btnpurpose01.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/btnpurpose01.jpg","type":"image","viewTime":10000},
+     {"fileName":"btnpurpose02.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/btnpurpose02.jpg","type":"image","viewTime":10000},
+     {"fileName":"purpose_index02.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/purpose/our-purpose/purpose_index02.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+   '[
+     {"fileName":"btnpurpose03.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/btnpurpose03.jpg","type":"image","viewTime":10000},
+     {"fileName":"sustainability.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/top/sustainability.jpg","type":"image","viewTime":10000},
+     {"fileName":"img_visual_01_sp.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/service/img_visual_01_sp.jpg","type":"image","viewTime":10000},
+     {"fileName":"advantage_thumb.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/service/advantage_thumb.jpg","type":"image","viewTime":10000},
+     {"fileName":"purpose_index06.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/purpose/our-purpose/purpose_index06.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd',
+   '[
+     {"fileName":"interview_thumbnail_bnt7.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_bnt7.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_bnt6.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_bnt6.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_bnt4.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_bnt4.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_bnt3.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_bnt3.jpg","type":"image","viewTime":10000},
+     {"fileName":"purpose_index03.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/purpose/our-purpose/purpose_index03.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+   '[
+     {"fileName":"interview_thumbnail_yms7.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_yms7.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_yms6.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_yms6.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_yms5.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_yms5.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_yms4.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_yms4.jpg","type":"image","viewTime":10000},
+     {"fileName":"purpose_index04.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/purpose/our-purpose/purpose_index04.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff',
+   '[
+     {"fileName":"interview_thumbnail_ope6.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_ope6.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_ope5.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_ope5.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_ope4.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_ope4.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_ope3.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_ope3.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('11111111-aaaa-bbbb-cccc-111111111111',
+   '[
+     {"fileName":"interview_thumbnail_bnt2.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_bnt2.jpg","type":"image","viewTime":10000},
+     {"fileName":"interview_thumbnail_ope2.jpg","path":"https://www.openupgroup.co.jp/_assets/images/purpose/open-upper/interview_thumbnail_ope2.jpg","type":"image","viewTime":10000},
+     {"fileName":"img03.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/011/img03.jpg","type":"image","viewTime":10000},
+     {"fileName":"img03.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/009/img03.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('22222222-aaaa-bbbb-cccc-222222222222',
+   '[
+     {"fileName":"img04.png","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/001/img04.png","type":"image","viewTime":10000},
+     {"fileName":"img02.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/002/img02.jpg","type":"image","viewTime":10000},
+     {"fileName":"img01.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/004/img01.jpg","type":"image","viewTime":10000},
+     {"fileName":"img01.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/005/img01.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb),
+  ('33333333-aaaa-bbbb-cccc-333333333333',
+   '[
+     {"fileName":"img05.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/006/img05.jpg","type":"image","viewTime":10000},
+     {"fileName":"img02.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/007/img02.jpg","type":"image","viewTime":10000},
+     {"fileName":"img04.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/case/008/img04.jpg","type":"image","viewTime":10000},
+     {"fileName":"purpose_index01_1.jpg","path":"https://www.openupgroup.co.jp/_assets/images/RN/purpose/our-purpose/purpose_index01_1.jpg","type":"image","viewTime":10000}
+   ]'::jsonb, '[]'::jsonb);
 
 -- Seed pixel_sizes
 insert into public.pixel_sizes (id, width, height, pixel_width, pixel_height, margin_top, margin_left, display_content_flg, get_pixel_flg) values
@@ -54,9 +112,15 @@ insert into public.pixel_sizes (id, width, height, pixel_width, pixel_height, ma
 -- Seed contents (areas)
 insert into public.contents (id, area_id, area_name, order_id, pixel_size_id, deleted) values
   (gen_random_uuid(), '0', '関東', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
-  (gen_random_uuid(), '1', '関西', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', null, false);
+  (gen_random_uuid(), '1', '関西', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '2', '北海道', 'dddddddd-dddd-dddd-dddd-dddddddddddd', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '3', '東北', 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '4', '中部', 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '5', '中国', '11111111-aaaa-bbbb-cccc-111111111111', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '6', '四国', '22222222-aaaa-bbbb-cccc-222222222222', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false),
+  (gen_random_uuid(), '7', '九州', '33333333-aaaa-bbbb-cccc-333333333333', 'cccccccc-cccc-cccc-cccc-cccccccccccc', false);
 
 -- Seed users profile
 insert into public.users (id, email, user_name, management, coverage_area, pass_flg, deleted) values
-  ('11111111-1111-1111-1111-111111111111', 'admin@example.com', '管理者', true, '{0,1}', false, false),
+  ('11111111-1111-1111-1111-111111111111', 'admin@example.com', '管理者', true, '{0,1,2,3,4,5,6,7}', false, false),
   ('22222222-2222-2222-2222-222222222222', 'user@example.com', '一般ユーザー', false, '{0}', false, false);


### PR DESCRIPTION
## Summary by Sourcery

シードされるアプリケーションデータの拡充と、コアなフロントエンド依存関係の更新を行いました。

新機能:
- 複数の地域に対応した、より現実的な画像メタデータを持つ追加注文データをシード。
- 新しい注文およびピクセルサイズに紐づいた、新規の地域コンテンツエントリをシード。

改善点:
- シードデータ内の管理ユーザーの対応エリアを拡大し、定義済みのすべての地域をカバー。
- Next.js、React、React DOM、Supabase ライブラリを最新のマイナー／パッチバージョンへ更新。
- 更新された依存関係に合わせて、bun のロックファイルおよび prepare-state のチェックサムを更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand seeded application data and update core frontend dependencies.

New Features:
- Seed additional orders with realistic image metadata for various regions.
- Seed new regional content entries linked to the new orders and pixel sizes.

Enhancements:
- Broaden admin user coverage areas in the seed data to include all defined regions.
- Update Next.js, React, React DOM, and Supabase libraries to their latest minor/patch versions.
- Refresh bun lockfile and prepare-state checksums to align with updated dependencies.

</details>