### PR TITLE
ci: fix security issue on comment.yml

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -23,16 +23,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: ⚙️ Setup Environment
-        run: |
-          echo "PR_NUMBER=$(cat pr_number/pr_number.txt | tr -cd '0-9')" >> "$GITHUB_ENV"
-          UUID=$(uuidgen)
-          {
-            echo "COMMENT<<EOF_$UUID"
-            cat comment/comment.txt
-            echo "EOF_$UUID"
-          } >> "$GITHUB_ENV"
-
       - name: 💬 Add a comment
         uses: actions/github-script@v8
         env:
@@ -40,13 +30,18 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         with:
           script: |
+            const fs = require('fs');
+
+            const prNumber = fs.readFileSync('pr_number/pr_number.txt', 'utf8').replace(/[^0-9]/g, '');
+            const comment = fs.readFileSync('comment/comment.txt', 'utf8');
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
+              issue_number: prNumber,
             })
-            const oldComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(process.env.WORKFLOW_NAME)
+            const oldComment = comments.find(c => {
+              return c.user.type === 'Bot' && c.body.includes(process.env.WORKFLOW_NAME)
             })
             const shouldComment = oldComment || process.env.CONCLUSION === 'failure'
             if (!shouldComment) return
@@ -60,6 +55,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
-              body: process.env.COMMENT
+              issue_number: prNumber,
+              body: comment
             })

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ supabase/.temp
 *.tsbuildinfo
 next-env.d.ts
 
-# Kiro settings
+# AI settings
 .claude
 
 # Docs


### PR DESCRIPTION
## Summary by Sourcery

CI:
- `github-script` ステップ内でファイルから PR 番号とコメント本文を読み取るようにコメント用ワークフローを調整し、`GITHUB_ENV` を通じて値を設定しないようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust the comment workflow to read the PR number and comment text from files inside the github-script step rather than populating them through GITHUB_ENV.

</details>