### PR TITLE
ci: disable fork repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build Rspress
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'openup-labtakizawa'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary by Sourcery

CI:
- デプロイ用ワークフローのビルドジョブが、リポジトリのオーナーが `openup-labtakizawa` の場合にのみ実行されるよう制限しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Limit the deploy workflow's build job to run only when the repository owner is 'openup-labtakizawa'.

</details>