### PR TITLE
ci: parallelize Playwright tests by browser via GitHub Actions matrix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,6 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
     env:
       DATABASE_URL: postgres://raspi:raspi@127.0.0.1:54322/raspi_signage
       BETTER_AUTH_SECRET: ci-better-auth-secret-not-for-production
@@ -76,16 +81,16 @@ jobs:
         run: bun scripts/db-bootstrap.ts
 
       - name: 🎭 Install Playwright Browsers
-        run: bun playwright install --with-deps
+        run: bun playwright install --with-deps ${{ matrix.browser }}
 
       - name: 🧪 Run Playwright tests
-        run: bun playwright test
+        run: bun playwright test --project=${{ matrix.browser }}
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 30
 

--- a/app/dashboard/login/page.tsx
+++ b/app/dashboard/login/page.tsx
@@ -25,8 +25,6 @@ interface SnackbarStatus {
 }
 
 export default function LoginPage(): React.JSX.Element {
-  const [email, setEmail] = useState<string>("")
-  const [password, setPassword] = useState<string>("")
   const [status, setStatus] = useState<SnackbarStatus>({
     open: false,
     type: "",
@@ -49,11 +47,17 @@ export default function LoginPage(): React.JSX.Element {
     setStatus({ ...status, open: false })
   }
 
-  // Handle form submission
+  // Handle form submission. Read directly from the submitted form's DOM
+  // values rather than from React state — controlled-input state can lag
+  // behind synthetic input events on WebKit + Playwright `page.fill`,
+  // which would otherwise let an empty `email` slip past validation.
   const onSubmit = async (
     event: React.FormEvent<HTMLFormElement>,
   ): Promise<void> => {
     event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const email = String(formData.get("email") ?? "")
+    const password = String(formData.get("password") ?? "")
     const regex = /^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,}$/
     const isValidEmail = regex.test(email)
     if (!isValidEmail) {
@@ -127,9 +131,6 @@ export default function LoginPage(): React.JSX.Element {
               label="メールアドレス"
               name="email"
               autoComplete="email"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setEmail(e.target.value)
-              }
               autoFocus
             />
             <TextField
@@ -141,9 +142,6 @@ export default function LoginPage(): React.JSX.Element {
               type="password"
               id="password"
               autoComplete="current-password"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setPassword(e.target.value)
-              }
             />
             <Button
               type="submit"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,12 +12,27 @@ const config: PlaywrightTestConfig = {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: process.env.CI
+    ? [
+        {
+          name: "chromium",
+          use: { ...devices["Desktop Chrome"] },
+        },
+        {
+          name: "firefox",
+          use: { ...devices["Desktop Firefox"] },
+        },
+        {
+          name: "webkit",
+          use: { ...devices["Desktop Safari"] },
+        },
+      ]
+    : [
+        {
+          name: "chromium",
+          use: { ...devices["Desktop Chrome"] },
+        },
+      ],
   webServer: {
     command: "bun dev",
     url: "http://localhost:3000",


### PR DESCRIPTION

Run Chromium, Firefox, and WebKit as independent matrix jobs in CI to
shorten total wall-clock time. Each job installs only the browser it
needs and uploads its own report artifact.

Local `bun playwright test` keeps the existing single-browser
(Chromium) sequential behavior, since matrix parallelism is a
CI-only optimization.

Also fixes a latent bug in the dashboard login form that the new
WebKit job surfaced: the previous onSubmit read `email` and
`password` from React state set asynchronously by onChange. On
WebKit, controlled-input state updates can lag behind synthetic
input events from Playwright's `page.fill`, letting an empty
`email` reach the regex check and triggering the validation error
dialog before sign-in is even attempted. Switching to FormData
reads the submitted DOM values directly and removes the race.
