### PR TITLE
build(vscode): add rumdl extension to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["biomejs.biome", "ms-playwright.playwright"]
+  "recommendations": ["biomejs.biome", "ms-playwright.playwright", "rvben.rumdl"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["biomejs.biome", "ms-playwright.playwright", "rvben.rumdl"]
+  "recommendations": [
+    "biomejs.biome",
+    "ms-playwright.playwright",
+    "rvben.rumdl"
+  ]
 }


### PR DESCRIPTION
Add rvben.rumdl to .vscode/extensions.json so editor users get the same
rumdl linting as the CLI configured in .rumdl.toml.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Build:
- エディター内で一貫した rumdl のリントを行えるようにするため、VS Code ワークスペースの推奨拡張機能に `rvben.rumdl` 拡張機能を追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add the rvben.rumdl extension to VS Code workspace recommendations for consistent rumdl linting in the editor.

</details>