### PR TITLE
fix(autofix.ci): apply automated fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/material-nextjs": "^9.0.1",
-        "@vercel/blob": "^2.3.3",
+        "@vercel/blob": "^2.4.0",
         "better-auth": "^1.6.11",
         "next": "^16.2.6",
         "pg": "^8.21.0",
@@ -346,7 +346,7 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@vercel/blob": ["@vercel/blob@2.3.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg=="],
+    "@vercel/blob": ["@vercel/blob@2.4.0", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/material-nextjs": "^9.0.1",
-    "@vercel/blob": "^2.3.3",
+    "@vercel/blob": "^2.4.0",
     "better-auth": "^1.6.11",
     "next": "^16.2.6",
     "pg": "^8.21.0",


### PR DESCRIPTION
## Summary by Sourcery

機能強化:
- `package.json` 内の `@vercel/blob` 依存関係をバージョン 2.3.3 から 2.4.0 に引き上げました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Bump @vercel/blob dependency from 2.3.3 to 2.4.0 in package.json.

</details>