### PR TITLE
fix: bun test mock isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,18 @@ bun run test:e2e          # E2E tests (Playwright)
 - Test files are located in `test/unit/` and `test/e2e/`
 - Do not add or modify tests unless explicitly requested
 
+### Test mocks
+
+- `bun:test`'s `mock.module` is **process-global**, and on `bun-version: canary` the *first*
+  registration's object shape fixes a module's exported-name set for the whole run. A mock that
+  omits an export makes any later file's static `import { thatExport }` fail to LINK
+  (`SyntaxError: Export named '…' not found`). Never register a partial module shape.
+- Build the shared global mocks via the typed factories under `test/mocks/`
+  (`db-client.ts`, `auth-guard.ts`, `storage.ts`). Their `typeof import("@/src/…")` return type
+  turns a missing export into a compile error, so the registry's name set stays complete regardless
+  of file order. Mock the `@/src/…` alias only (the alias and a relative specifier resolve to the
+  same module key).
+
 ## Code style
 
 - Linting and formatting managed by Biome

--- a/test/mocks/auth-guard.ts
+++ b/test/mocks/auth-guard.ts
@@ -1,0 +1,27 @@
+// Shared, completeness-guaranteed mock for `@/src/auth/guard`.
+// See `test/mocks/db-client.ts` for the full rationale (bun:test mock.module is process-global and
+// the first registration fixes the exported-name set, so every mock must cover the whole surface).
+import { mock } from "bun:test"
+import type { SessionPayload } from "@/src/auth/guard"
+
+type Guard = typeof import("@/src/auth/guard")
+
+const defaultSession: SessionPayload = {
+  user: { id: "test-uid", email: "test@example.com" },
+}
+
+export function createGuardMock(
+  session: SessionPayload = defaultSession,
+): Guard {
+  return {
+    requireSession: async () => session,
+    requireAdmin: async () => session,
+    requireSelfOrAdmin: async () => session,
+    requireSelf: async () => session,
+    requireEmail: async () => session,
+  }
+}
+
+export function mockGuard(session?: SessionPayload): void {
+  mock.module("@/src/auth/guard", () => createGuardMock(session))
+}

--- a/test/mocks/db-client.ts
+++ b/test/mocks/db-client.ts
@@ -1,0 +1,52 @@
+// Shared, completeness-guaranteed mock for `@/src/db/client`.
+//
+// WHY THIS EXISTS — bun:test mock.module gotcha (empirically established, see #445):
+//   `mock.module` is PROCESS-GLOBAL. On `bun-version: canary` the FIRST registration's object
+//   shape fixes the module's exported-name set for the whole run. If that first shape omits an
+//   export (historically `withTransaction`, omitted only by getContentDataAdmin.test.ts), any later
+//   file whose graph statically imports the missing name fails to LINK:
+//   `SyntaxError: Export named 'withTransaction' not found in module 'src/db/client.ts'`.
+//   The export exists in source — this is a test-mock-completeness bug, and it is file-ORDER
+//   dependent (does not reproduce on stable 1.3.14 / local canary 1.4.0).
+//   A relative specifier and the `@/*` alias resolve to the SAME registry key, so mocking the
+//   alias alone covers every importer.
+//
+//   Fix-by-construction: declare the COMPLETE surface in ONE place. The `DbClientMock` key type
+//   (below) makes "forgot an export" a COMPILE error, so a registration can never be partial.
+import { mock } from "bun:test"
+
+type DbClient = typeof import("@/src/db/client")
+
+// Loose values (mocks intentionally return simplified shapes that don't satisfy pg's full
+// `QueryResult`/`readonly` signatures) but the EXACT key set: if db/client gains or renames an
+// export, `keyof DbClient` changes and `defaults` below fails to compile — that compile error is
+// the completeness guarantee, without forcing every mock closure to match the real signatures.
+type DbClientMock = Record<keyof DbClient, unknown>
+
+export function createDbClientMock(
+  overrides: Partial<DbClientMock> = {},
+): DbClient {
+  const defaults: DbClientMock = {
+    query: async () => ({ rows: [] }),
+    queryRows: async () => [],
+    queryOne: async () => null,
+    withTransaction: async <T>(
+      fn: (client: {
+        query: (
+          text: string,
+          params?: unknown[],
+        ) => Promise<{ rows: Record<string, unknown>[] }>
+      }) => Promise<T>,
+    ) => fn({ query: async () => ({ rows: [] }) }),
+    getPool: () => {
+      throw new Error(
+        "getPool is not mocked in unit tests; mock query/queryRows/queryOne/withTransaction instead",
+      )
+    },
+  }
+  return { ...defaults, ...overrides } as unknown as DbClient
+}
+
+export function mockDbClient(overrides: Partial<DbClientMock> = {}): void {
+  mock.module("@/src/db/client", () => createDbClientMock(overrides))
+}

--- a/test/mocks/storage.ts
+++ b/test/mocks/storage.ts
@@ -1,0 +1,24 @@
+// Shared, completeness-guaranteed mock for `@/src/storage`.
+// See `test/mocks/db-client.ts` for the full rationale (bun:test mock.module is process-global and
+// the first registration fixes the exported-name set, so every mock must cover the whole surface).
+import { mock } from "bun:test"
+import type { StorageDriver } from "@/src/storage"
+
+type Storage = typeof import("@/src/storage")
+
+export function createStorageMock(
+  driver: Partial<StorageDriver> = {},
+): Storage {
+  const defaultDriver: StorageDriver = {
+    upload: async (prefix, fileName) => ({
+      key: `${prefix}/${fileName}`,
+      url: "",
+    }),
+    list: async () => [],
+  }
+  return { getStorage: () => ({ ...defaultDriver, ...driver }) }
+}
+
+export function mockStorage(driver?: Partial<StorageDriver>): void {
+  mock.module("@/src/storage", () => createStorageMock(driver))
+}

--- a/test/unit/properties/serverClientDataCompat.test.ts
+++ b/test/unit/properties/serverClientDataCompat.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import * as fc from "fast-check"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockDbClient } from "../../mocks/db-client"
 
 interface State {
   rows: Record<string, unknown>[]
@@ -28,21 +30,8 @@ const dbMock = {
   ) => fn({ query: async () => ({ rows: state.rows }) }),
 }
 
-mock.module("../../../src/db/client", () => dbMock)
-mock.module("@/src/db/client", () => dbMock)
-
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockDbClient(dbMock)
+mockGuard()
 
 const { getContentsDataClient, getContentList, getOrderById } = await import(
   "../../../src/services/contents"

--- a/test/unit/utilities/download.test.ts
+++ b/test/unit/utilities/download.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockStorage } from "../../mocks/storage"
 
 interface State {
   listResult: { key: string; url: string }[]
@@ -10,30 +12,15 @@ const state: State = {
   listError: null,
 }
 
-mock.module("../../../src/storage", () => ({
-  getStorage: () => ({
-    upload: async () => ({ key: "", url: "" }),
-    list: async () => {
-      if (state.listError) {
-        throw state.listError
-      }
-      return state.listResult
-    },
-  }),
-}))
-
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockStorage({
+  list: async () => {
+    if (state.listError) {
+      throw state.listError
+    }
+    return state.listResult
+  },
+})
+mockGuard()
 
 const { downLoadURLList } = await import("../../../src/services/download")
 

--- a/test/unit/utilities/getContentDataAdmin.test.ts
+++ b/test/unit/utilities/getContentDataAdmin.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import fc from "fast-check"
+import { mockDbClient } from "../../mocks/db-client"
 
 interface QueryRecorder {
   text: string | null
@@ -13,7 +14,7 @@ const state: QueryRecorder = {
   result: { rows: [] },
 }
 
-mock.module("../../../src/db/client", () => ({
+mockDbClient({
   query: async (text: string, params?: unknown[]) => {
     state.text = text
     state.params = params ?? null
@@ -29,7 +30,7 @@ mock.module("../../../src/db/client", () => ({
     state.params = params ?? null
     return state.result.rows[0] ?? null
   },
-}))
+})
 
 const { getContentDataAdmin, getOrderIdAdmin } = await import(
   "../../../src/services/contents-admin"

--- a/test/unit/utilities/getContentDataClient.test.ts
+++ b/test/unit/utilities/getContentDataClient.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import fc from "fast-check"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockDbClient } from "../../mocks/db-client"
 
 interface State {
   text: string | null
@@ -36,21 +38,8 @@ const dbMock = {
   ) => fn({ query: async () => ({ rows: state.rows }) }),
 }
 
-mock.module("../../../src/db/client", () => dbMock)
-mock.module("@/src/db/client", () => dbMock)
-
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockDbClient(dbMock)
+mockGuard()
 
 const { getUserAccountList } = await import("../../../src/services/users")
 

--- a/test/unit/utilities/serverServices.test.ts
+++ b/test/unit/utilities/serverServices.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockDbClient } from "../../mocks/db-client"
 
 interface State {
   text: string | null
@@ -30,21 +32,8 @@ const dbMock = {
   ) => fn({ query: async () => ({ rows: state.rows }) }),
 }
 
-mock.module("../../../src/db/client", () => dbMock)
-mock.module("@/src/db/client", () => dbMock)
-
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockDbClient(dbMock)
+mockGuard()
 
 const { getContentsDataServer, getContentListServer, getOrderByIdServer } =
   await import("../../../src/services/contents-server")

--- a/test/unit/utilities/setContentData.test.ts
+++ b/test/unit/utilities/setContentData.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test"
 import fc from "fast-check"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockDbClient } from "../../mocks/db-client"
 
 interface QueryCall {
   text: string
@@ -70,21 +72,8 @@ const dbMock = {
   },
 }
 
-mock.module("../../../src/db/client", () => dbMock)
-mock.module("@/src/db/client", () => dbMock)
-
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockDbClient(dbMock)
+mockGuard()
 
 const authServerMock = {
   getAuth: () => ({

--- a/test/unit/utilities/upload.test.ts
+++ b/test/unit/utilities/upload.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, mock, test } from "bun:test"
+import { mockGuard } from "../../mocks/auth-guard"
+import { mockDbClient } from "../../mocks/db-client"
+import { mockStorage } from "../../mocks/storage"
 
 interface State {
   contentsRow: Record<string, unknown> | null
@@ -16,7 +19,7 @@ const state: State = {
   updateContentOrderCalls: [],
 }
 
-mock.module("../../../src/db/client", () => ({
+mockDbClient({
   queryOne: async (text: string) => {
     if (text.includes("FROM contents")) {
       return state.contentsRow
@@ -26,30 +29,20 @@ mock.module("../../../src/db/client", () => ({
     }
     return null
   },
-  query: async () => ({ rows: [] }),
-  queryRows: async () => [],
-  withTransaction: async <T>(
-    fn: (client: {
-      query: (text: string) => Promise<{ rows: Record<string, unknown>[] }>
-    }) => Promise<T>,
-  ) => fn({ query: async () => ({ rows: [] }) }),
-}))
+})
 
-mock.module("../../../src/storage", () => ({
-  getStorage: () => ({
-    upload: async (prefix: string, fileName: string) => {
-      state.uploadCalls.push({ prefix, fileName })
-      if (state.uploadError) {
-        throw state.uploadError
-      }
-      return {
-        key: `${prefix}/${fileName}`,
-        url: `http://localhost:9000/signage-contents/${prefix}/${fileName}`,
-      }
-    },
-    list: async () => [],
-  }),
-}))
+mockStorage({
+  upload: async (prefix: string, fileName: string) => {
+    state.uploadCalls.push({ prefix, fileName })
+    if (state.uploadError) {
+      throw state.uploadError
+    }
+    return {
+      key: `${prefix}/${fileName}`,
+      url: `http://localhost:9000/signage-contents/${prefix}/${fileName}`,
+    }
+  },
+})
 
 mock.module("../../../src/services/contents", () => ({
   updateContentOrder: async (
@@ -60,18 +53,7 @@ mock.module("../../../src/services/contents", () => ({
   },
 }))
 
-const fakeSession = {
-  user: { id: "test-uid", email: "test@example.com" },
-}
-const guardMock = {
-  requireSession: async () => fakeSession,
-  requireAdmin: async () => fakeSession,
-  requireSelfOrAdmin: async () => fakeSession,
-  requireSelf: async () => fakeSession,
-  requireEmail: async () => fakeSession,
-}
-mock.module("../../../src/auth/guard", () => guardMock)
-mock.module("@/src/auth/guard", () => guardMock)
+mockGuard()
 
 const { postContent } = await import("../../../src/services/upload")
 


### PR DESCRIPTION
## Summary by Sourcery

コアインフラストラクチャモジュール向けの共有かつ型安全な Bun テストモックを導入し、ユニットテストを更新して、それらを利用することでプロセス全体でのモック隔離を信頼性高く行えるようにします。

Enhancements:
- テストごとに場当たり的に作成していた db クライアント、auth ガード、storage 用の Bun モジュールモックを廃止し、`test/mocks/` 配下に共有の型付きモックファクトリを定義して、テスト間でモックのインターフェイスを完全かつ一貫して保てるようにします。

Documentation:
- Bun のプロセス全体で共有される `mock.module` の挙動と、新しい共有モックユーティリティについて `AGENTS.md` に記載します。

Tests:
- ユニットテストをリファクタリングし、ローカルモックを定義する代わりに共有の db-client、auth-guard、storage モックを利用するように変更し、Bun canary 環境下で発生する部分的なモジュールモックの問題を回避します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce shared, type-safe Bun test mocks for core infrastructure modules and update unit tests to use them for reliable, process-global mock isolation.

Enhancements:
- Replace ad-hoc per-test Bun module mocks for db client, auth guard, and storage with shared typed mock factories under test/mocks/ to ensure complete and consistent mock surfaces across tests.

Documentation:
- Document Bun's process-global mock.module behavior and the new shared mock utilities in AGENTS.md.

Tests:
- Refactor unit tests to consume the shared db-client, auth-guard, and storage mocks instead of defining local mocks and to avoid partial module mocking issues under Bun canary.

</details>