### PR TITLE
chore: update biome settings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,11 @@
     "defaultBranch": "main"
   },
   "linter": {
+    "domains": {
+      "next": "recommended",
+      "react": "recommended",
+      "test": "recommended"
+    },
     "rules": {
       "correctness": {
         "noNestedComponentDefinitions": "off",
@@ -30,11 +35,6 @@
   "json": {
     "formatter": {
       "indentStyle": "space"
-    }
-  },
-  "css": {
-    "parser": {
-      "tailwindDirectives": true
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
-        "@mui/material-nextjs": "^9.1.1",
+        "@mui/material-nextjs": "^9.3.0",
         "@vercel/blob": "^2.6.1",
         "better-auth": "^1.6.26",
         "next": "^16.3.0",
@@ -240,7 +240,7 @@
 
     "@mui/material": ["@mui/material@9.2.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@mui/core-downloads-tracker": "^9.2.0", "@mui/system": "^9.2.0", "@mui/types": "^9.1.1", "@mui/utils": "^9.2.0", "@popperjs/core": "^2.11.8", "@types/react-transition-group": "^4.4.12", "clsx": "^2.1.1", "csstype": "^3.2.3", "prop-types": "^15.8.1", "react-is": "^19.2.6", "react-transition-group": "^4.4.5" }, "peerDependencies": { "@emotion/react": "^11.5.0", "@emotion/styled": "^11.3.0", "@mui/material-pigment-css": "^9.2.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/react", "@emotion/styled", "@mui/material-pigment-css", "@types/react"] }, "sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg=="],
 
-    "@mui/material-nextjs": ["@mui/material-nextjs@9.1.1", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "@emotion/cache": "^11.11.0", "@emotion/react": "^11.11.4", "@emotion/server": "^11.11.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/cache", "@emotion/server", "@types/react"] }, "sha512-OUM0a2GvzKXkkFxKBjs6O36pXv5/vhmgET+k6XNaKR+gG2B4wU1rlGuUkynddbvuVqgdF5ZjElIZAf2W7TRMZA=="],
+    "@mui/material-nextjs": ["@mui/material-nextjs@9.3.0", "", { "dependencies": { "@babel/runtime": "^7.29.7" }, "peerDependencies": { "@emotion/cache": "^11.11.0", "@emotion/react": "^11.11.4", "@emotion/server": "^11.11.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/cache", "@emotion/server", "@types/react"] }, "sha512-wtI2u7+Sb+xsbn0aPOofYKD2kGD3BreAaLDEFTuf1gQl+IB8kqcTn+UU6OvJ+hAVbFlTXpvD2oVDkOTeCzjVmQ=="],
 
     "@mui/private-theming": ["@mui/private-theming@9.2.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@mui/utils": "^9.2.0", "prop-types": "^15.8.1" }, "peerDependencies": { "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-w9wpyDxGPGnAACPB2hKhCDmILJIAvQxrfjUbIAEa0AznX1rOjaz5N+yB1uuw8ixnJcpEh/tPbD9oEe19wcWPHw=="],
 
@@ -597,6 +597,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@happy-dom/global-registrator/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@mui/material-nextjs/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@types/ws/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
-    viewTransition: true,
   },
   output: "standalone",
   reactCompiler: true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test:unit": "bun test test/unit --preload ./happydom.ts",
+    "test:unit": "bun test test/unit --preload ./happydom.ts --isolate --randomize",
     "test:e2e": "playwright test",
     "db:bootstrap": "bun scripts/db-bootstrap.ts",
     "db:migrate": "bun scripts/db-migrate.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
-    "@mui/material-nextjs": "^9.1.1",
+    "@mui/material-nextjs": "^9.3.0",
     "@vercel/blob": "^2.6.1",
     "better-auth": "^1.6.26",
     "next": "^16.3.0",

--- a/test/unit/utilities/upload.test.ts
+++ b/test/unit/utilities/upload.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { mockGuard } from "../../mocks/auth-guard"
 import { mockDbClient } from "../../mocks/db-client"
 import { mockStorage } from "../../mocks/storage"
+
+interface QueryCall {
+  text: string
+  params: unknown[] | null
+}
 
 interface State {
   contentsRow: Record<string, unknown> | null
   orderRow: Record<string, unknown> | null
   uploadCalls: { prefix: string; fileName: string }[]
   uploadError: Error | null
-  updateContentOrderCalls: unknown[]
+  queryCalls: QueryCall[]
 }
 
 const state: State = {
@@ -16,10 +21,14 @@ const state: State = {
   orderRow: null,
   uploadCalls: [],
   uploadError: null,
-  updateContentOrderCalls: [],
+  queryCalls: [],
 }
 
 mockDbClient({
+  query: async (text: string, params?: unknown[]) => {
+    state.queryCalls.push({ text, params: params ?? null })
+    return { rows: [] }
+  },
   queryOne: async (text: string) => {
     if (text.includes("FROM contents")) {
       return state.contentsRow
@@ -44,15 +53,6 @@ mockStorage({
   },
 })
 
-mock.module("../../../src/services/contents", () => ({
-  updateContentOrder: async (
-    docId: string,
-    content: Record<string, unknown>,
-  ) => {
-    state.updateContentOrderCalls.push([docId, content])
-  },
-}))
-
 mockGuard()
 
 const { postContent } = await import("../../../src/services/upload")
@@ -62,14 +62,37 @@ function reset() {
   state.orderRow = null
   state.uploadCalls = []
   state.uploadError = null
-  state.updateContentOrderCalls = []
+  state.queryCalls = []
+}
+
+// `updateContentOrder` emits `UPDATE orders SET hidden = $n::jsonb WHERE id = $last`
+// with the hidden list JSON-encoded. Recover the call the way the old
+// `updateContentOrder` stub used to record it.
+function orderUpdates(): {
+  docId: string
+  hidden: Record<string, unknown>[]
+}[] {
+  return state.queryCalls
+    .filter((call) => call.text.includes("UPDATE orders"))
+    .map((call) => {
+      const hiddenIndex = call.text.match(/hidden = \$(\d+)::jsonb/)?.[1]
+      if (!hiddenIndex) {
+        throw new Error(`no hidden assignment in query: ${call.text}`)
+      }
+      return {
+        docId: call.params?.at(-1) as string,
+        hidden: JSON.parse(
+          call.params?.[Number(hiddenIndex) - 1] as string,
+        ) as Record<string, unknown>[],
+      }
+    })
 }
 
 describe("postContent", () => {
   test("returns early when content has no name", async () => {
     reset()
     await postContent("doc-1", {} as File, "image", 0)
-    expect(state.updateContentOrderCalls).toHaveLength(0)
+    expect(orderUpdates()).toHaveLength(0)
     expect(state.uploadCalls).toHaveLength(0)
   })
 
@@ -77,7 +100,7 @@ describe("postContent", () => {
     reset()
     state.contentsRow = null
     await postContent("doc-1", { name: "test.png" } as File, "image", 0)
-    expect(state.updateContentOrderCalls).toHaveLength(0)
+    expect(orderUpdates()).toHaveLength(0)
   })
 
   test("returns early on upload error", async () => {
@@ -85,7 +108,7 @@ describe("postContent", () => {
     state.contentsRow = { area_id: "0" }
     state.uploadError = new Error("fail")
     await postContent("doc-1", { name: "test.png" } as File, "image", 0)
-    expect(state.updateContentOrderCalls).toHaveLength(0)
+    expect(orderUpdates()).toHaveLength(0)
   })
 
   test("uploads file and appends to hidden", async () => {
@@ -94,14 +117,11 @@ describe("postContent", () => {
     state.orderRow = { hidden: [{ fileName: "old.png" }] }
     await postContent("doc-1", { name: "new.png" } as File, "image", 5000)
     expect(state.uploadCalls).toEqual([{ prefix: "0", fileName: "new.png" }])
-    expect(state.updateContentOrderCalls).toHaveLength(1)
-    const [docId, content] = state.updateContentOrderCalls[0] as [
-      string,
-      { hidden: Record<string, unknown>[] },
-    ]
-    expect(docId).toBe("doc-1")
-    expect(content.hidden).toHaveLength(2)
-    expect(content.hidden[1]).toEqual({
+    const updates = orderUpdates()
+    expect(updates).toHaveLength(1)
+    expect(updates[0].docId).toBe("doc-1")
+    expect(updates[0].hidden).toHaveLength(2)
+    expect(updates[0].hidden[1]).toEqual({
       fileName: "new.png",
       path: "http://localhost:9000/signage-contents/0/new.png",
       type: "image",
@@ -114,10 +134,6 @@ describe("postContent", () => {
     state.contentsRow = { area_id: "1" }
     state.orderRow = { hidden: [] }
     await postContent("doc-1", { name: "vid.mp4" } as File, "video", 0)
-    const [, content] = state.updateContentOrderCalls[0] as [
-      string,
-      { hidden: { viewTime: number }[] },
-    ]
-    expect(content.hidden[0].viewTime).toBe(2000)
+    expect(orderUpdates()[0].hidden[0].viewTime).toBe(2000)
   })
 })


### PR DESCRIPTION
## Summary by Sourcery

アップロードのユニットテストを、新しいデータベースクエリベースのコンテンツ順序更新に合わせて調整し、プロジェクトのツーリング設定を更新します。

Enhancements:
- 未使用のビュー遷移サポートを削除して、Next.js の experimental 設定を整理します。

Build:
- テストの分離とランダム化を有効にすることで、Bun のユニットテスト実行をより厳密にします。

Tests:
- コンテンツサービスをスタブする代わりに、共有モック DB クライアントを通じてアップロードテスト内で SQL の順序更新呼び出しを取得し、アサートします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align upload unit tests with new database query-based content order updates and adjust project tooling configuration.

Enhancements:
- Refine Next.js experimental configuration by removing unused view transition support.

Build:
- Tighten Bun unit test invocation by enabling test isolation and randomization.

Tests:
- Capture and assert SQL order update calls in upload tests via the shared mock DB client instead of stubbing the content service.

</details>