### PR TITLE
chore: remove standalone build

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -15,7 +15,13 @@ permissions:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    # The workflows above upload the artifacts only when they conclude with
+    # success or failure. Any other conclusion, such as a run cancelled by
+    # cancel-in-progress, leaves nothing to download.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: 📥 Download artifact
         uses: actions/download-artifact@v8

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
   },
-  output: "standalone",
   reactCompiler: true,
   typedRoutes: true,
   images: {


### PR DESCRIPTION
## Summary by Sourcery

コメント用ワークフローを、完了した pull_request ワークフロー実行時にのみ動作するように制限し、Next.js 設定から standalone 出力構成を削除します。

Build:
- Next.js の設定から standalone 出力オプションを削除。

CI:
- 元となる pull_request ワークフローが成功または失敗で終了した場合にのみ、コメント用ワークフローがトリガーされるように更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict the comment workflow to only run for completed pull_request workflow runs and remove the standalone output configuration from the Next.js setup.

Build:
- Remove the standalone output option from the Next.js configuration.

CI:
- Update the comment workflow to trigger only when the originating pull_request workflow concludes with success or failure.

</details>